### PR TITLE
受講生更新画面に削除チェックボックスを追加、過去の受講生リストを作成

### DIFF
--- a/src/main/java/raisetech/student/management/controller/StudentController.java
+++ b/src/main/java/raisetech/student/management/controller/StudentController.java
@@ -1,0 +1,87 @@
+package raisetech.student.management.controller;
+
+import java.util.List;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import raisetech.student.management.controller.converter.StudentConverter;
+import raisetech.student.management.model.data.Student;
+import raisetech.student.management.model.data.StudentCourse;
+import raisetech.student.management.model.domain.StudentDetail;
+import raisetech.student.management.model.services.StudentService;
+
+@Controller
+public class StudentController {
+
+  private final StudentService service;
+  private final StudentConverter converter;
+  private List<StudentDetail> studentsDetails; // コントローラーのフィールドとして空のstudentDetailを定義
+
+  public StudentController(StudentService service, StudentConverter converter) {
+    this.service = service;
+    this.converter = converter;
+  }
+
+  @GetMapping("/students")
+  public String getStudentList(Model model) {
+    List<Student> students = service.searchStudentList();
+    List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
+    studentsDetails = converter.convertStudentDetails(students, studentsCourses).stream()
+        .filter(studentDetail -> !studentDetail.getStudent().isDeleted())
+        .toList();
+
+    model.addAttribute("studentList", studentsDetails);
+    return "studentList";
+  }
+
+  @GetMapping("/students/past")
+  public String getPastStudentList(Model model) {
+    List<Student> students = service.searchStudentList();
+    List<StudentCourse> studentsCourses = service.searchStudentsCourseList();
+    studentsDetails = converter.convertStudentDetails(students, studentsCourses).stream()
+        .filter(studentDetail -> studentDetail.getStudent().isDeleted())
+        .toList();
+
+    model.addAttribute("pastStudentList", studentsDetails);
+    return "pastStudentList";
+  }
+
+  @GetMapping("/students/new")
+  public String newStudent(Model model) {
+    model.addAttribute("studentDetail", new StudentDetail());
+    return "registerStudent";
+  }
+
+  @GetMapping("/students/{id}")
+  public String getStudent(@PathVariable int id, Model model) {
+    StudentDetail studentDetail = service.searchStudent(id);
+    model.addAttribute("studentDetail", studentDetail);
+    return "updateStudent";
+  }
+
+
+  @PostMapping("/students/new")
+  // ビューの登録フォームで入力されたstudentDetailの情報をstudentServiceに送る
+  public String registerStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "registerStudent";
+    }
+
+    // フォームで入力されたstudentDetailのstudentの情報とstudentCourseの情報（最初の一つ）をserviceにあるregisterStudentメソッドの引数とする
+    service.registerStudent(studentDetail);
+    return "redirect:/students";
+  }
+
+  @PostMapping("/students/update")
+  public String updateStudent(@ModelAttribute StudentDetail studentDetail, BindingResult result) {
+    if (result.hasErrors()) {
+      return "updateStudent";
+    }
+    service.updateStudent(studentDetail);
+    return "redirect:/students";
+  }
+}

--- a/src/main/resources/templates/pastStudentList.html
+++ b/src/main/resources/templates/pastStudentList.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>過去の受講生一覧</title>
+</head>
+<body>
+<h1>過去の受講生一覧</h1>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>ふりがな</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>住所</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>受講コース</th>
+    <th>備考</th>
+    <th>更新</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail : ${pastStudentList}">
+    <!--  以下、タグ内のデフォルト値（山田太郎など）はプレースホルダ{fullnameなど}によって置き換えられる-->
+    <td th:text="${studentDetail.student.id}">1</td>
+    <td th:text="${studentDetail.student.fullname}">山田太郎</td>
+    <td th:text="${studentDetail.student.furigana}">やまだたろう</td>
+    <td th:text="${studentDetail.student.nickname}">やまちゃん</td>
+    <td th:text="${studentDetail.student.mail}">mailadress@example.com</td>
+    <td th:text="${studentDetail.student.address}">東京</td>
+    <td th:text="${studentDetail.student.age}">26</td>
+    <td th:text="${studentDetail.student.gender}">男性</td>
+    <td>
+      <span th:each="course, iterStat : ${studentDetail.studentCourse}">
+        <span th:text="${course.courseName}"></span>
+        <span th:if="${!iterStat.last}">,</span>
+      </span>
+    </td>
+    <td th:text="${studentDetail.student.remark}">特になし</td>
+    <td>
+      <a th:href="@{/students/{id}(id=${studentDetail.student.id})}"><p>更新</p></a>
+    </td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/studentList.html
+++ b/src/main/resources/templates/studentList.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!--名前空間の宣言。thを持つ属性をThymeleafの属性として認識させることができる-->
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生一覧</title>
+</head>
+<body>
+<h1>受講生一覧</h1>
+<a th:href="@{/students/new}">新規登録</a>
+<br>
+<a th:href="@{/students/past}">過去の受講生一覧</a>
+<table border="1">
+  <thead>
+  <tr>
+    <th>ID</th>
+    <th>名前</th>
+    <th>ふりがな</th>
+    <th>ニックネーム</th>
+    <th>メールアドレス</th>
+    <th>住所</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>受講コース</th>
+    <th>備考</th>
+    <th>更新</th>
+  </tr>
+  </thead>
+  <tbody>
+  <tr th:each="studentDetail : ${studentList}">
+    <!--  以下、タグ内のデフォルト値（山田太郎など）はプレースホルダ{fullnameなど}によって置き換えられる-->
+    <td th:text="${studentDetail.student.id}">1</td>
+    <td th:text="${studentDetail.student.fullname}">山田太郎</td>
+    <td th:text="${studentDetail.student.furigana}">やまだたろう</td>
+    <td th:text="${studentDetail.student.nickname}">やまちゃん</td>
+    <td th:text="${studentDetail.student.mail}">mailadress@example.com</td>
+    <td th:text="${studentDetail.student.address}">東京</td>
+    <td th:text="${studentDetail.student.age}">26</td>
+    <td th:text="${studentDetail.student.gender}">男性</td>
+    <td>
+      <span th:each="course, iterStat : ${studentDetail.studentCourse}">
+        <span th:text="${course.courseName}"></span>
+        <span th:if="${!iterStat.last}">,</span>
+      </span>
+    </td>
+    <td th:text="${studentDetail.student.remark}">特になし</td>
+    <td>
+      <a th:href="@{/students/{id}(id=${studentDetail.student.id})}"><p>更新</p></a>
+    </td>
+  </tr>
+  </tbody>
+</table>
+</body>
+</html>

--- a/src/main/resources/templates/updateStudent.html
+++ b/src/main/resources/templates/updateStudent.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>受講生詳細</title>
+</head>
+<body>
+<h1>受講生詳細</h1>
+<form th:action="@{/students/update}" th:object="${studentDetail}" method="post">
+  <input type="hidden" th:field="*{student.id}" th:value="*{student.id}"/>
+  <div>
+    <label for="fullname">氏名（必須）:</label>
+    <input type="text" id="fullname" th:field="*{student.fullname}" required/>
+  </div>
+  <div>
+    <label for="furigana">ふりがな（必須）:</label>
+    <input type="text" id="furigana" th:field="*{student.furigana}" required/>
+  </div>
+  <div>
+    <label for="nickname">ニックネーム（任意）:</label>
+    <input type="text" id="nickname" th:field="*{student.nickname}"/>
+  </div>
+  <div>
+    <label for="mail">メールアドレス（必須）:</label>
+    <input type="text" id="mail" th:field="*{student.mail}" required/>
+  </div>
+  <div>
+    <label for="address">住所（任意）:</label>
+    <input type="text" id="address" th:field="*{student.address}"/>
+  </div>
+  <div>
+    <label for="age">年齢（任意）:</label>
+    <input type="text" id="age" th:field="*{student.age}"/>
+  </div>
+  <div>
+    <label for="gender">性別（任意）:</label>
+    <input type="text" id="gender" th:field="*{student.gender}"/>
+  </div>
+  <div>
+    <label for="remark">備考（任意）:</label>
+    <input type="text" id="remark" th:field="*{student.remark}"/>
+  </div>
+  <div th:each="course, stat : *{studentCourse}">
+    <!-- idをフォーム入力せずに既存のものと対応づけるため、ユーザーに見えない形で取得 -->
+    <input type="hidden" th:field="*{studentCourse[__${stat.index}__].id}"
+           th:value="*{studentCourse[__${stat.index}__].id}"/>
+    <label for="courseName"
+           th:for="*{studentCourse[__${stat.index}__].courseName}">受講コース:</label>
+    <input type="text" id="courseName" th:id="*{studentCourse[__${stat.index}__].courseName}"
+           th:field="*{studentCourse[__${stat.index}__].courseName}"
+           required/>
+  </div>
+  <div>
+    <label for="isDeleted">削除:</label>
+    <input type="checkbox" id="isDeleted" th:field="*{student.deleted}"/>
+  </div>
+  <div>
+    <button type="submit">更新</button>
+  </div>
+</form>
+</body>
+</html>


### PR DESCRIPTION
**新カリキュラム第30回の課題を以下のとおり実施いたしましたので、ご確認をお願いいたします。**
***
## 概要

**◆受講生詳細ページに、受講生を論理削除するためのチェックボックスを追加しました。チェックを入れて更新ボタンをクリックすると、受講生のdeleted属性がTrueに更新され、「受講生一覧」に表示されなくなります。**

**◆受講生一覧ページに「過去の受講生一覧」のハイパーリンクを追加しました。これをクリックすると、deleted属性がtrueの受講生が一覧表示されます。**

**◆MySQLで事前に用意したデータテーブルは、以下の通りです**
1.students
<img src="https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/fd863991-a9ad-4d63-a282-c36027fbf962" width="100%">  

2.students_courses
  <img src="https://github.com/YaraiM/JavaNewChapter29Assignment/assets/153747182/156fc58a-54ef-4e9f-a95e-2e58377266f4" width="70%">

***
 
## 動作確認

**1. パスとして/studentsを指定すると、受講生一覧が表示されます。「更新」をクリックすると、その受講生の情報を更新するページに遷移します。（前回の課題と同様）**
<kbd><img src="https://github.com/YaraiM/JavaNewChapter30Assignment/assets/153747182/37bef636-d7d3-4c28-94be-fa6cfbf0c483" width="80%"></kbd>    


**2. 表示された受講生詳細に「削除」チェックボックスが表示されています。これにチェックを入れて更新すると、受講生一覧から表示されなくなります。表示されなくなった受講生は、過去の受講生一覧をクリックすると表示されます。**  

<kbd><img src="https://github.com/YaraiM/JavaNewChapter30Assignment/assets/153747182/2d254067-470b-47db-a059-c6b951a182e8" width="80%"></kbd>  

<kbd><img src="https://github.com/YaraiM/JavaNewChapter30Assignment/assets/153747182/4b19bd38-ddfc-466d-9994-b970d8fc4577" width="80%"></kbd>  

<kbd><img src="https://github.com/YaraiM/JavaNewChapter30Assignment/assets/153747182/722507b6-6ce8-49ad-bbf0-b6d1a57081e0" width="80%"></kbd>  

**3. DBを確認すると、受講生情報のdeletedが「1」(=True)に更新されていることが分かります。**
<img src="https://github.com/YaraiM/JavaNewChapter30Assignment/assets/153747182/91952e49-d4bf-4a3a-924c-0081cc5ce52b" width="100%">
